### PR TITLE
Add pesticide sensor fusion and extra sensor support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+HOST=0.0.0.0
+PORT=8000
+API_KEY=your_api_key
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@db/gambusia
+# Twilio settings for SMS alerts
+TWILIO_SID=your_account_sid
+TWILIO_TOKEN=your_auth_token
+TWILIO_NUMBER=+1xxxxxxxxxx
+ALERT_PHONE=+1xxxxxxxxxx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest -v --cov=.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11 as builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# Gambusia API
+
+This project exposes a minimal API for collecting mosquito sensor readings and computing a risk score. It uses FastAPI with an async SQLAlchemy ORM layer.
+By default the application expects a running PostgreSQL instance and reads the connection string from `DATABASE_URL`.
+
+## Setup
+
+Create a Python environment and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Redis must be running locally for caching features. Endpoints are protected with a simple API key provided via the `X-API-Key` header. Set `API_KEY` in your `.env` file before starting the server.
+
+Database tables are created automatically on startup for convenience. For
+production deployments consider managing schema changes with a migration tool
+such as **Alembic**.
+
+## Running the server
+
+Use `main.py` to start the service. All configuration values are loaded from
+environment variables via `gambusia.config`. Copy `.env.example` to `.env` and
+adjust the values before starting the server:
+
+```bash
+HOST=0.0.0.0
+PORT=8000
+API_KEY=your_api_key
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@db/gambusia
+# optional notification settings
+TWILIO_SID=your_account_sid
+TWILIO_TOKEN=your_auth_token
+TWILIO_NUMBER=+1xxxxxxxxxx
+ALERT_PHONE=+1xxxxxxxxxx
+```
+
+```bash
+python main.py
+```
+
+## API Endpoints
+
+### POST /submit
+Stores a single sensor reading and returns a risk score with reasons.
+
+### POST /submit/sms
+Form-based variant for low-tech devices sending readings via SMS gateway.
+
+### GET /map
+Returns the last 100 readings along with their risk scores.
+
+### GET /map/geojson
+Returns the same data formatted as GeoJSON for GIS tools.
+
+### WebSocket /alerts
+Sends a text alert when incoming data includes a risk score over 0.8.
+
+## Testing
+
+```bash
+pytest -q
+```
+
+## Docker
+
+Build and run the application inside a container:
+
+```bash
+docker build -t gambusia .
+docker run -p 8000:8000 gambusia
+```
+
+For local development you can start PostgreSQL and Redis using Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+## Continuous Integration
+
+This repository includes a simple GitHub Actions workflow that installs dependencies and runs the tests on each push.
+
+## LoRa Gateway
+
+`lora_gateway.py` demonstrates how to read LoRa messages from a serial port and
+forward them to the API using HTTP requests. Adjust the serial settings and API
+key as needed for your deployment.
+
+## Notifications
+
+Push notifications use Firebase if `firebase-credentials.json` is present.
+SMS alerts are sent via Twilio when the following environment variables are set:
+`TWILIO_SID`, `TWILIO_TOKEN`, `TWILIO_NUMBER` and `ALERT_PHONE`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db/gambusia
+      - API_KEY=${API_KEY}
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+  redis:
+    image: redis:alpine
+volumes:
+  pg_data:

--- a/gambusia/api.py
+++ b/gambusia/api.py
@@ -1,0 +1,232 @@
+from datetime import datetime
+import json
+from contextlib import asynccontextmanager
+import asyncio
+import logging
+from fastapi import FastAPI, Form, WebSocket, WebSocketDisconnect, Security, HTTPException, Depends
+from fastapi.responses import JSONResponse
+from fastapi.security import APIKeyHeader
+from redis import Redis
+
+from .models import SensorData, RiskResponse
+from .risk import calculate_risk, calculate_pesticide_risk, is_rice_field
+from .database import get_db, init_db, Reading
+from .config import settings
+from .notifications import (
+    send_push_notification,
+    send_sms_alert,
+    registered_device_tokens,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger("gambusia")
+alerts_queue: asyncio.Queue[dict] = asyncio.Queue()
+
+redis: Redis | None = None
+API_KEY = settings.API_KEY
+api_key_header = APIKeyHeader(name="X-API-Key")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global redis
+    await init_db()
+    redis = Redis(host="localhost", decode_responses=True)
+    try:
+        yield
+    finally:
+        if redis is not None:
+            try:
+                redis.close()
+            except Exception:
+                pass
+
+
+app = FastAPI(
+    title="Gambusia - Risk API",
+    description="API for collecting sensor data and calculating mosquito risk scores.",
+    lifespan=lifespan,
+)
+
+
+async def get_api_key(api_key: str = Security(api_key_header)) -> str:
+    if api_key != API_KEY:
+        raise HTTPException(status_code=403, detail="Invalid API Key")
+    return api_key
+
+
+@app.post(
+    "/submit",
+    response_model=RiskResponse,
+    summary="Submit a sensor reading",
+    description="""Record a new reading and return the calculated risk score.""",
+)
+async def submit_data(
+    data: SensorData,
+    api_key: str = Security(get_api_key),
+    session: AsyncSession = Depends(get_db),
+):
+    if data.timestamp is None:
+        data.timestamp = datetime.utcnow()
+    cfg = "ipsala_risk_config.json" if is_rice_field(data.lat, data.lon) else None
+    risk, reasons = calculate_risk(
+        data.temp,
+        data.humidity,
+        data.freq,
+        data.image_verified,
+        timestamp=data.timestamp,
+        config=cfg,
+    )
+    pesticide_risk, pest_reasons = calculate_pesticide_risk(data.extra_sensors)
+    reading = Reading(
+        timestamp=data.timestamp,
+        device_id=data.device_id,
+        temp=data.temp,
+        humidity=data.humidity,
+        freq=data.freq,
+        image_verified=data.image_verified,
+        lat=data.lat,
+        lon=data.lon,
+        extra_sensors=data.extra_sensors,
+    )
+    session.add(reading)
+    logger.info(
+        "Reading received", extra={"device_id": data.device_id, "risk": risk}
+    )
+    if risk > 0.8:
+        await send_push_notification(data.device_id, risk)
+        await send_sms_alert(data.device_id, risk)
+        alerts_queue.put_nowait({"device_id": data.device_id, "risk_score": risk})
+    return RiskResponse(
+        risk_score=risk,
+        pesticide_risk=pesticide_risk,
+        message="Veri alındı ve risk skoru hesaplandı.",
+        reasons=reasons + pest_reasons,
+    )
+
+
+@app.post(
+    "/submit/sms",
+    response_model=RiskResponse,
+    summary="Submit sensor data via SMS",
+    description="Accept form-encoded sensor data for low-tech devices.",
+)
+async def submit_via_sms(
+    device_id: str = Form(...),
+    temp: float = Form(...),
+    humidity: float = Form(...),
+    freq: int = Form(0),
+    image_verified: bool = Form(False),
+    lat: float = Form(...),
+    lon: float = Form(...),
+    api_key: str = Security(get_api_key),
+    session: AsyncSession = Depends(get_db),
+):
+    data = SensorData(
+        device_id=device_id,
+        temp=temp,
+        humidity=humidity,
+        freq=freq,
+        image_verified=image_verified,
+        lat=lat,
+        lon=lon,
+    )
+    return await submit_data(data, api_key=api_key, session=session)
+
+
+@app.get(
+    "/map",
+    summary="Retrieve recent readings",
+    description="Return last 100 readings with calculated risk scores.",
+)
+async def map_data(
+    api_key: str = Security(get_api_key),
+    session: AsyncSession = Depends(get_db),
+):
+    cached = None
+    if redis is not None:
+        try:
+            cached = redis.get("last_map")
+        except Exception:
+            cached = None
+    if cached:
+        return json.loads(cached)
+    result = await session.execute(
+        select(Reading).order_by(Reading.id.desc()).limit(100)
+    )
+    rows = result.scalars().all()
+    results = []
+    for r in rows:
+        risk, reasons = calculate_risk(
+            r.temp, r.humidity, r.freq, r.image_verified, timestamp=r.timestamp
+        )
+        pest_risk, _ = calculate_pesticide_risk(r.extra_sensors)
+        results.append(
+            {
+                "device_id": r.device_id,
+                "lat": r.lat,
+                "lon": r.lon,
+                "temp": r.temp,
+                "humidity": r.humidity,
+                "freq": r.freq,
+                "image_verified": r.image_verified,
+                "extra_sensors": r.extra_sensors,
+                "timestamp": r.timestamp.isoformat() if r.timestamp else None,
+                "risk_score": risk,
+                "reasons": reasons,
+                "pesticide_risk": pest_risk,
+            }
+        )
+    if redis is not None:
+        try:
+            redis.setex("last_map", 60, json.dumps(results))
+        except Exception as e:
+            print(f"Redis cache write error: {e}")
+    return results
+
+
+@app.websocket("/alerts")
+async def alert_notifier(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            msg = await alerts_queue.get()
+            await websocket.send_text(
+                f"ACIL: {msg['device_id']} noktasinda sivrisinek riski yuksek! skor: {msg['risk_score']}"
+            )
+    except WebSocketDisconnect:
+        pass
+
+
+@app.get(
+    "/map/geojson",
+    summary="Retrieve recent readings as GeoJSON",
+    description="Return last 100 readings formatted as GeoJSON FeatureCollection.",
+)
+async def map_geojson(
+    api_key: str = Security(get_api_key),
+    session: AsyncSession = Depends(get_db),
+):
+    result = await session.execute(
+        select(Reading).order_by(Reading.id.desc()).limit(100)
+    )
+    rows = result.scalars().all()
+    features = []
+    for r in rows:
+        risk, _ = calculate_risk(
+            r.temp, r.humidity, r.freq, r.image_verified, timestamp=r.timestamp
+        )
+        pest_risk, _ = calculate_pesticide_risk(r.extra_sensors)
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [r.lon, r.lat]},
+                "properties": {
+                    "risk_score": risk,
+                    "pesticide_risk": pest_risk,
+                    **(r.extra_sensors or {}),
+                },
+            }
+        )
+    return JSONResponse({"type": "FeatureCollection", "features": features})

--- a/gambusia/calibration.py
+++ b/gambusia/calibration.py
@@ -1,0 +1,23 @@
+"""Simple calibration state tracking for sensors."""
+
+from typing import Dict
+
+
+class CalibrationState:
+    def __init__(self, device_id: str) -> None:
+        self.device_id = device_id
+        self.zero_points: Dict[str, float] = {}
+        self.last_readings: Dict[str, float] = {}
+
+    def update(self, current_readings: Dict[str, float]) -> None:
+        self.last_readings = current_readings
+
+    def set_zero_point(self, sensor: str, value: float) -> None:
+        self.zero_points[sensor] = value
+
+    def is_drift_detected(self) -> bool:
+        for k, zero in self.zero_points.items():
+            current = self.last_readings.get(k)
+            if current is not None and abs(current - zero) > 5:
+                return True
+        return False

--- a/gambusia/config.py
+++ b/gambusia/config.py
@@ -1,0 +1,28 @@
+from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Settings(BaseSettings):
+    HOST: str = "0.0.0.0"
+    PORT: int = 8000
+    API_KEY: str | None = None
+    DATABASE_URL: str = (
+        "postgresql+asyncpg://postgres:postgres@localhost/gambusia?connect_timeout=5"
+    )
+    TWILIO_SID: str | None = None
+    TWILIO_TOKEN: str | None = None
+    TWILIO_NUMBER: str | None = None
+    ALERT_PHONE: str | None = None
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+def get_settings() -> Settings:
+    return Settings()
+
+settings = get_settings()
+
+if not settings.API_KEY:
+    print("Warning: API_KEY not set")

--- a/gambusia/database.py
+++ b/gambusia/database.py
@@ -1,0 +1,60 @@
+from contextlib import asynccontextmanager
+from datetime import datetime
+
+from .config import settings
+
+from sqlalchemy import Column, Integer, Float, Boolean, String, DateTime, JSON
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = settings.DATABASE_URL
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+
+AsyncSessionLocal = sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+)
+
+Base = declarative_base()
+
+
+class Reading(Base):
+    __tablename__ = "readings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    device_id = Column(String, nullable=False)
+    temp = Column(Float)
+    humidity = Column(Float)
+    freq = Column(Integer)
+    image_verified = Column(Boolean)
+    lat = Column(Float)
+    lon = Column(Float)
+    extra_sensors = Column(JSON)
+
+
+async def init_db() -> None:
+    """Create database tables if they do not exist.
+
+    Note
+    ----
+    This helper is intended for development only. In production deployments
+    migrations managed by a tool such as Alembic should be used instead of
+    calling ``create_all`` directly.
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_db() -> AsyncSession:
+    """Yield an async SQLAlchemy session."""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        finally:
+            await session.close()

--- a/gambusia/fusion.py
+++ b/gambusia/fusion.py
@@ -1,0 +1,41 @@
+"""Pesticide sensor fusion utilities."""
+
+from typing import Tuple, List, Dict
+
+
+def fuse_pesticide_signals(extra: Dict[str, float] | None) -> Tuple[float, List[str]]:
+    """Return pesticide risk score based on extra sensor readings."""
+    if not extra:
+        return 0.0, []
+
+    score = 0.0
+    reasons: List[str] = []
+
+    voc = extra.get("voc")
+    nh3 = extra.get("nh3")
+    ph = extra.get("ph")
+    orp = extra.get("orp")
+
+    if voc is not None and nh3 is not None:
+        if voc > 400 and nh3 > 50:
+            score += 0.6
+            reasons.append("voc_and_nh3_high")
+        elif voc > 400:
+            score += 0.3
+            reasons.append("voc_high")
+    elif voc is not None and voc > 400:
+        score += 0.3
+        reasons.append("voc_high")
+
+    if orp is not None and orp > 700:
+        score += 0.2
+        reasons.append("orp_high")
+
+    if ph is not None and (ph < 5.5 or ph > 7.5):
+        score += 0.2
+        reasons.append("ph_out_of_range")
+
+    # normalize
+    if score > 1:
+        score = 1.0
+    return round(score, 2), reasons

--- a/gambusia/ipsala_risk_config.json
+++ b/gambusia/ipsala_risk_config.json
@@ -1,0 +1,7 @@
+{
+  "temp": {"min": 25, "max": 37, "weight": 0.4, "reason": "\u00c7eltik tarlasi icin ideal sicaklik"},
+  "humidity": {"threshold": 80, "weight": 0.5, "reason": "Çeltik suyu yüksek risk"},
+  "freq": {"min": 200, "max": 600, "weight": 0.1, "reason": "Anopheles turu frekans araligi"},
+  "image_verified": {"weight": 0.1, "reason": "Goruntu dogrulama basarili"}
+}
+

--- a/gambusia/models.py
+++ b/gambusia/models.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional, Dict, Any
+from datetime import datetime
+
+
+class SensorData(BaseModel):
+    """Incoming sensor reading."""
+
+    device_id: str
+    timestamp: Optional[datetime] = None
+    temp: float = Field(
+        ..., ge=10, le=50, description="Temperature in Celsius"
+    )  # tighter bounds for Ipsala
+    humidity: float = Field(
+        ..., ge=0, le=100, description="Relative humidity %"
+    )
+    freq: int = Field(..., ge=0, le=2000, description="Wing beat frequency in Hz")
+    image_verified: bool
+    lat: float
+    lon: float
+    extra_sensors: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Additional chemical sensor readings as key/value pairs",
+    )
+
+    @field_validator("humidity")
+    def check_humidity(cls, v: float) -> float:
+        if not 0 <= v <= 100:
+            raise ValueError("Nem %0-100 aralığında olmalı")
+        return v
+
+
+class RiskResponse(BaseModel):
+    risk_score: float
+    pesticide_risk: float | None = None
+    message: str
+    reasons: list[str]

--- a/gambusia/notifications.py
+++ b/gambusia/notifications.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import os
+from firebase_admin import messaging, credentials, initialize_app
+from twilio.rest import Client
+
+from .config import settings
+
+registered_device_tokens: dict[str, str] = {}
+
+# Initialize Firebase if credentials are available
+firebase_ready = False
+if os.path.exists("firebase-credentials.json"):
+    cred = credentials.Certificate("firebase-credentials.json")
+    initialize_app(cred)
+    firebase_ready = True
+else:
+    print("Firebase credentials missing - push notifications disabled")
+
+
+async def send_push_notification(device_id: str, risk_score: float) -> None:
+    if not firebase_ready:
+        return
+    token = registered_device_tokens.get(device_id)
+    if not token:
+        return
+    message = messaging.Message(
+        notification=messaging.Notification(
+            title="Yüksek Risk!",
+            body=f"{device_id} noktasında risk skoru: {risk_score}",
+        ),
+        token=token,
+    )
+    messaging.send(message)
+
+
+async def send_sms_alert(device_id: str, risk_score: float) -> None:
+    sid = settings.TWILIO_SID
+    token = settings.TWILIO_TOKEN
+    from_number = settings.TWILIO_NUMBER
+    to_number = settings.ALERT_PHONE
+    if not all([sid, token, from_number, to_number]):
+        return
+    client = Client(sid, token)
+    client.messages.create(
+        body=f"Risk Uyarısı: {device_id} skor {risk_score}",
+        from_=from_number,
+        to=to_number,
+    )

--- a/gambusia/risk.py
+++ b/gambusia/risk.py
@@ -1,0 +1,123 @@
+"""Risk scoring utilities."""
+
+import json
+import os
+from typing import Tuple, Union
+from .fusion import fuse_pesticide_signals
+from datetime import datetime
+from shapely.geometry import Point, Polygon
+
+# polygon for Ipsala rice fields (rough bounding box)
+IPSALA_POLYGON = [
+    (26.3, 40.9),
+    (26.5, 40.9),
+    (26.5, 41.0),
+    (26.3, 41.0),
+]
+_POLYGON = Polygon(IPSALA_POLYGON)
+
+
+def is_rice_field(lat: float, lon: float) -> bool:
+    """Return True if given coordinates fall into the Ipsala rice field area."""
+    return Point(lon, lat).within(_POLYGON)
+
+
+def get_seasonal_weight(month: int) -> float:
+    """Return risk multiplier based on the month."""
+    return 0.8 if 6 <= month <= 9 else 0.2
+
+
+DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), "risk_config.json")
+
+
+def load_config(path: str = DEFAULT_CONFIG) -> dict:
+    """Load risk calculation configuration from ``path``."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def calculate_risk(
+    temp: float,
+    humidity: float,
+    freq: int,
+    image_verified: bool,
+    *,
+    timestamp: datetime | None = None,
+    config: Union[dict, str, None] = None,
+) -> Tuple[float, list[str]]:
+    """Calculate risk score using a configuration file.
+
+    Parameters
+    ----------
+    temp : float
+        Temperature reading.
+    humidity : float
+        Humidity reading.
+    freq : int
+        Wing beat frequency.
+    image_verified : bool
+        Whether an image verification succeeded.
+    timestamp : datetime | None
+        Time of the reading for seasonal weighting.
+    config : dict | None
+        Optional configuration. If not provided, ``risk_config.json`` is used.
+
+    Returns
+    -------
+    Tuple[float, list[str]]
+        Final risk score and a list of reasons that contributed to the score.
+    """
+
+    if config is None:
+        config_dict = load_config()
+    elif isinstance(config, str):
+        config_dict = load_config(config)
+    else:
+        config_dict = config
+
+    score = 0.0
+    reasons: list[str] = []
+
+    # temperature check
+    temp_cfg = config_dict.get("temp", {})
+    if temp_cfg:
+        if temp_cfg.get("min") <= temp <= temp_cfg.get("max"):
+            score += temp_cfg.get("weight", 0)
+            reasons.append(temp_cfg.get("reason", "temperature"))
+
+    # humidity check
+    hum_cfg = config_dict.get("humidity", {})
+    if hum_cfg:
+        if humidity > hum_cfg.get("threshold", 0):
+            score += hum_cfg.get("weight", 0)
+            reasons.append(hum_cfg.get("reason", "humidity"))
+
+    # frequency check
+    freq_cfg = config_dict.get("freq", {})
+    if freq_cfg:
+        if freq_cfg.get("min") <= freq <= freq_cfg.get("max"):
+            score += freq_cfg.get("weight", 0)
+            reasons.append(freq_cfg.get("reason", "freq"))
+
+    # image verification check
+    img_cfg = config_dict.get("image_verified", {})
+    if img_cfg and image_verified:
+        score += img_cfg.get("weight", 0)
+        reasons.append(img_cfg.get("reason", "image_verified"))
+
+    if timestamp is None:
+        timestamp = datetime.utcnow()
+    weight = get_seasonal_weight(timestamp.month)
+    score *= weight
+    reasons.append(f"seasonal_weight={weight}")
+
+    return round(score, 2), reasons
+
+
+def calculate_pesticide_risk(extra: dict | None) -> Tuple[float, list[str]]:
+    """Wrapper around :func:`fuse_pesticide_signals` for convenience."""
+
+    score, reasons = fuse_pesticide_signals(extra)
+    return score, reasons
+

--- a/gambusia/risk_config.json
+++ b/gambusia/risk_config.json
@@ -1,0 +1,6 @@
+{
+  "temp": {"min": 22, "max": 34, "weight": 0.3, "reason": "Uygun sıcaklık"},
+  "humidity": {"threshold": 60, "weight": 0.3, "reason": "Nem yüksek"},
+  "freq": {"min": 250, "max": 700, "weight": 0.3, "reason": "Uygun kanat frekansı"},
+  "image_verified": {"weight": 0.1, "reason": "Görüntü doğrulandı"}
+}

--- a/lora_gateway.py
+++ b/lora_gateway.py
@@ -1,0 +1,41 @@
+import serial
+import requests
+import json
+
+API_URL = "http://localhost:8000/submit"
+API_KEY = "your_api_key"
+
+SERIAL_PORT = "/dev/ttyUSB0"
+BAUDRATE = 9600
+
+
+def parse_lora_message(line: str) -> dict:
+    parts = line.strip().split(",")
+    return {
+        "temp": float(parts[0]),
+        "humidity": float(parts[1]),
+        "freq": int(parts[2]),
+        "image_verified": parts[3].lower() == "true",
+        "lat": float(parts[4]),
+        "lon": float(parts[5]),
+    }
+
+
+def main() -> None:
+    ser = serial.Serial(SERIAL_PORT, BAUDRATE, timeout=2)
+    print("LoRa Gateway listening...")
+    while True:
+        line = ser.readline().decode("utf-8").strip()
+        if not line:
+            continue
+        try:
+            data = parse_lora_message(line)
+            headers = {"x-api-key": API_KEY}
+            r = requests.post(API_URL, json=data, headers=headers)
+            print("Submitted:", data, "\u2192", r.status_code)
+        except Exception as exc:
+            print("Error:", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,10 @@
+from gambusia.api import app
+from gambusia.config import settings
+import uvicorn
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=settings.HOST, port=settings.PORT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+fastapi==0.115.14
+uvicorn[standard]==0.35.0
+python-dotenv==1.1.1
+pydantic==2.11.7
+sqlalchemy==2.0.41
+redis==6.2.0
+httpx==0.28.1
+python-multipart==0.0.20
+asyncpg==0.30.0
+aiosqlite==0.21.0
+shapely==2.1.1
+firebase-admin==6.9.0
+twilio==9.6.3
+pydantic-settings==2.1.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,160 @@
+import os
+import sys
+import tempfile
+import sqlite3
+import asyncio
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# configure temporary database before importing the app
+db_path = os.path.join(tempfile.gettempdir(), "test_gambusia.db")
+os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{db_path}"
+os.environ["API_KEY"] = "testkey"
+
+from gambusia.api import app
+from gambusia.database import init_db
+
+asyncio.get_event_loop().run_until_complete(init_db())
+client = TestClient(app)
+
+
+def clear_db():
+    path = db_path
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM readings")
+        conn.commit()
+
+
+def test_submit_endpoint_inserts_row():
+    clear_db()
+    payload = {
+        "device_id": "dev1",
+        "temp": 30,
+        "humidity": 65,
+        "freq": 300,
+        "image_verified": True,
+        "lat": 1.0,
+        "lon": 2.0,
+        "extra_sensors": {"voc": 500, "nh3": 60},
+    }
+    response = client.post("/submit", json=payload, headers={"X-API-Key": "testkey"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["risk_score"] > 0
+    assert data["pesticide_risk"] > 0
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM readings")
+        count = cur.fetchone()[0]
+    assert count == 1
+
+
+def test_submit_invalid_input():
+    clear_db()
+    payload = {
+        "device_id": "dev2",
+        "temp": -100,
+        "humidity": 50,
+        "freq": 100,
+        "image_verified": False,
+        "lat": 0,
+        "lon": 0,
+    }
+    resp = client.post("/submit", json=payload, headers={"X-API-Key": "testkey"})
+    assert resp.status_code == 422
+
+
+def test_timestamp_and_reasons_added():
+    clear_db()
+    payload = {
+        "device_id": "dev3",
+        "temp": 30,
+        "humidity": 70,
+        "freq": 300,
+        "image_verified": True,
+        "lat": 5.0,
+        "lon": 6.0,
+    }
+    resp = client.post("/submit", json=payload, headers={"X-API-Key": "testkey"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["reasons"]
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT timestamp FROM readings ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    assert row[0]
+
+
+def test_map_endpoint_returns_data():
+    clear_db()
+    payload = {
+        "device_id": "dev-map",
+        "temp": 28,
+        "humidity": 60,
+        "freq": 350,
+        "image_verified": False,
+        "lat": 0,
+        "lon": 0,
+        "extra_sensors": {"voc": 450},
+    }
+    client.post("/submit", json=payload, headers={"X-API-Key": "testkey"})
+    response = client.get("/map", headers={"X-API-Key": "testkey"})
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["extra_sensors"] == {"voc": 450}
+
+
+def test_invalid_api_key():
+    payload = {
+        "device_id": "devX",
+        "temp": 30,
+        "humidity": 60,
+        "freq": 300,
+        "image_verified": False,
+        "lat": 0,
+        "lon": 0,
+    }
+    resp = client.post("/submit", json=payload, headers={"X-API-Key": "wrong"})
+    assert resp.status_code == 403
+
+
+def test_geojson_endpoint():
+    clear_db()
+    payload = {
+        "device_id": "geo",
+        "temp": 30,
+        "humidity": 70,
+        "freq": 300,
+        "image_verified": True,
+        "lat": 1,
+        "lon": 1,
+        "extra_sensors": {"ph": 6.8},
+    }
+    client.post("/submit", json=payload, headers={"X-API-Key": "testkey"})
+    resp = client.get("/map/geojson", headers={"X-API-Key": "testkey"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == "FeatureCollection"
+    assert data["features"]
+    props = data["features"][0]["properties"]
+    assert "ph" in props
+
+
+def test_websocket_alert():
+    with client.websocket_connect("/alerts") as ws:
+        payload = {
+            "device_id": "ws1",
+            "temp": 30,
+            "humidity": 90,
+            "freq": 300,
+            "image_verified": True,
+            "lat": 0,
+            "lon": 0,
+        }
+        client.post("/submit", json=payload, headers={"X-API-Key": "testkey"})
+        text = ws.receive_text()
+        assert "ACIL" in text

--- a/tests/test_extra_sensors.py
+++ b/tests/test_extra_sensors.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import tempfile
+import sqlite3
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# configure temp db
+path = os.path.join(tempfile.gettempdir(), "extra.db")
+os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{path}"
+os.environ["API_KEY"] = "tkey"
+
+from gambusia.api import app
+from gambusia.database import init_db
+
+import asyncio
+asyncio.get_event_loop().run_until_complete(init_db())
+client = TestClient(app)
+
+
+def clear_db():
+    with sqlite3.connect(path) as conn:
+        conn.execute("DELETE FROM readings")
+        conn.commit()
+
+
+def test_extra_sensor_storage():
+    clear_db()
+    payload = {
+        "device_id": "e1",
+        "temp": 25,
+        "humidity": 70,
+        "freq": 250,
+        "image_verified": False,
+        "lat": 0,
+        "lon": 0,
+        "extra_sensors": {"nh3": 55},
+    }
+    resp = client.post("/submit", json=payload, headers={"X-API-Key": "tkey"})
+    assert resp.status_code == 200
+    with sqlite3.connect(path) as conn:
+        row = conn.execute("SELECT extra_sensors FROM readings").fetchone()
+    assert row[0] is not None

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,0 +1,18 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gambusia.fusion import fuse_pesticide_signals
+
+
+def test_high_voc_nh3():
+    score, reasons = fuse_pesticide_signals({"voc": 500, "nh3": 70})
+    assert score == 0.6
+    assert "voc_and_nh3_high" in reasons
+
+
+def test_orp_ph_contribution():
+    score, reasons = fuse_pesticide_signals({"orp": 750, "ph": 8.0})
+    assert score > 0
+    assert "orp_high" in reasons
+    assert "ph_out_of_range" in reasons

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from datetime import datetime
+from gambusia.risk import calculate_risk, is_rice_field, get_seasonal_weight
+
+
+def test_calculate_risk_positive():
+    ts = datetime(2024, 6, 1)
+    score, reasons = calculate_risk(30, 65, 300, True, timestamp=ts)
+    assert score == 0.8
+    assert reasons
+
+
+def test_calculate_risk_zero():
+    ts = datetime(2024, 6, 1)
+    score, reasons = calculate_risk(10, 40, 100, False, timestamp=ts)
+    assert score == 0.0
+    assert "seasonal_weight" in reasons[-1]
+
+
+def test_custom_config():
+    config = {
+        "temp": {"min": 0, "max": 10, "weight": 0.5, "reason": "soğuk"},
+    }
+    ts = datetime(2024, 1, 1)
+    score, reasons = calculate_risk(5, 0, 0, False, timestamp=ts, config=config)
+    assert score == 0.1
+    assert "soğuk" in reasons
+
+
+def test_is_rice_field():
+    assert is_rice_field(40.95, 26.4)
+    assert not is_rice_field(39.0, 28.0)
+
+
+def test_get_seasonal_weight():
+    assert get_seasonal_weight(6) == 0.8
+    assert get_seasonal_weight(1) == 0.2


### PR DESCRIPTION
## Summary
- extend data models to include `extra_sensors`
- add pesticide risk calculation utilities
- store extra sensor data in database
- expose pesticide risk scores via API and GeoJSON
- add calibration skeleton and unit tests for fusion logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68542317e814832d860b03c2871b2a55